### PR TITLE
Update to v.2.0.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,6 +32,13 @@ about:
   license_family: BSD
   license_file: LICENSE.rst
   summary: A Python module that implements the jinja2.Markup string
+  description: |
+    MarkupSafe is a library for Python that implements a unicode string that
+    is aware of HTML escaping rules and can be used to implement automatic
+    string escaping. It is used by Jinja 2, the Mako templating engine, the
+    Pylons web framework and many more.
+  doc_url: https://pypi.python.org/pypi/MarkupSafe
+  doc_source_url: https://github.com/pallets/markupsafe/blob/master/README.rst
   dev_url: https://github.com/pallets/markupsafe
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.1.1" %}
+{% set version = "2.0.0" %}
 
 package:
   name: markupsafe
@@ -6,14 +6,15 @@ package:
 
 source:
   url: https://pypi.io/packages/source/M/MarkupSafe/MarkupSafe-{{ version }}.tar.gz
-  sha256: 29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b
+  sha256: 4fae0677f712ee090721d8b17f412f1cbceefbf0dc180fe91bab3232f38b4527
 
 build:
   number: 0
-  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+  script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
   build:
+    - python                                 # [build_platform != target_platform]
     - {{ compiler('c') }}
   host:
     - python
@@ -31,13 +32,6 @@ about:
   license_family: BSD
   license_file: LICENSE.rst
   summary: A Python module that implements the jinja2.Markup string
-  description: |
-    MarkupSafe is a library for Python that implements a unicode string that
-    is aware of HTML escaping rules and can be used to implement automatic
-    string escaping. It is used by Jinja 2, the Mako templating engine, the
-    Pylons web framework and many more.
-  doc_url: https://pypi.python.org/pypi/MarkupSafe
-  doc_source_url: https://github.com/pallets/markupsafe/blob/master/README.rst
   dev_url: https://github.com/pallets/markupsafe
 
 extra:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a fork of the feedstock to propose changes
* [X] Bumped the build number (if the version is unchanged)
* [X] Reset the build number to `0` (if the version changed)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Updated to v2.0.0 from upstream source. Some significant changes.
jinja2 3.0.0 requires this version of markupsafe


<!--
Please add any other relevant info below:
-->

The package markupsafe is inside the packages:
cookiecutter
jinja2
mako
markupsafe
pyramid_jinja2
salt
wtforms

------

Category:  miniconda
Popularity: 
Branch: v2.0.0
Version change: bump Major version number from 1.1.1 to v2.0.0
Update branch: https://github.com/AnacondaRecipes/markupsafe-feedstock/blob/v2.0.0/recipe/meta.yaml
license: BSD-3-Clause
Release date: May 11, 2021, https://pypi.org/project/markupsafe/#history
Changelog: Drop Python 2.7, 3.4, and 3.5 support https://github.com/pallets/markupsafe/blob/main/CHANGES.rst
dev_url:  https://github.com/pallets/markupsafe
Bug Tracker: no new open issues https://github.com/pallets/markupsafe/issues
Github releases:  https://github.com/pallets/markupsafe/releases
Upstream setup.cfg:  https://github.com/pallets/markupsafe/blob/main/setup.cfg
Upstream setup.py:  https://github.com/pallets/markupsafe/blob/main/setup.py
Concourse builds correctly

Actions:
1. Updated dependencies in meta.yaml from upstream source 

Result:
- all-succeeded


