### PR TITLE
markupsafe 2.1.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.0.1" %}
+{% set version = "2.1.1" %}
 
 package:
   name: markupsafe
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/M/MarkupSafe/MarkupSafe-{{ version }}.tar.gz
-  sha256: 594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a
+  sha256: 7f91197cc9e48f989d12e4e6fbc46495c446636dfc81b9ccf50bb0ec74b91d4b
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,34 +10,43 @@ source:
 
 build:
   number: 0
+  skip: true  # [py<37]
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
   build:
-    - python                                 # [build_platform != target_platform]
     - {{ compiler('c') }}
   host:
     - python
     - pip
+    - setuptools
+    - wheel
   run:
     - python
+  run_constrained:
+    - jinja2 >=3.0.0
 
 test:
   imports:
     - markupsafe
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: https://www.palletsprojects.com/p/markupsafe
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE.rst
-  summary: A Python module that implements the jinja2.Markup string
+  summary: Safely add untrusted strings to HTML/XML markup.
   description: |
-    MarkupSafe is a library for Python that implements a unicode string that
-    is aware of HTML escaping rules and can be used to implement automatic
-    string escaping. It is used by Jinja 2, the Mako templating engine, the
-    Pylons web framework and many more.
-  doc_url: https://pypi.python.org/pypi/MarkupSafe
+      MarkupSafe implements a text object that escapes characters so it is
+      safe to use in HTML and XML. Characters that have special meanings are
+      replaced so that they display as the actual characters. This mitigates
+      injection attacks, meaning untrusted user input can safely be displayed
+      on a page.
+  doc_url: https://markupsafe.palletsprojects.com/
   doc_source_url: https://github.com/pallets/markupsafe/blob/master/README.rst
   dev_url: https://github.com/pallets/markupsafe
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,6 +33,10 @@ test:
     - pip
   commands:
     - pip check
+  downstreams:
+    - jinja2
+    # CI issues with testing downstream package astropy
+    - astropy  # [not win]
 
 about:
   home: https://www.palletsprojects.com/p/markupsafe

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,9 +33,9 @@ test:
     - pip
   commands:
     - pip check
-  downstreams:
-    - jinja2
+  downstreams:  # [not win]
     # CI issues with testing downstream package astropy
+    - jinja2  # [not win]
     - astropy  # [not win]
 
 about:


### PR DESCRIPTION
Update markupsafe to 2.1.1

Changelog: Drop Python 3.6 supporthttps://github.com/pallets/markupsafe/blob/2.1.1/CHANGES.rst
License: https://github.com/pallets/markupsafe/blob/2.1.1/LICENSE.rst
Bug Tracker: no new open issues https://github.com/pallets/markupsafe/issues
Upstream setup.cfg: https://github.com/pallets/markupsafe/blob/2.1.1/setup.cfg
Upstream setup.py: https://github.com/pallets/markupsafe/blob/2.1.1/setup.py

Actions:
1. Skip p`y<37`
2. Remove `python` from `req/build` as we do not cross-compile
3. Add missing packages `setuptools` and `wheel` in `host`
4. Add run_constrained: jinja2 >=3.0.0, see:
- https://github.com/conda-forge/markupsafe-feedstock/commit/ee7dadbd5cdf33dd2e338400f1b6ae40f261deeb,
- https://github.com/conda-forge/markupsafe-feedstock/pull/25,
- https://github.com/conda-forge/markupsafe-feedstock/issues/29
6. Add `pip check`
7. Update summary and description
8. Update `doc_url`
9. Add `downstreams`: `jinja2`, `atropy` for additional testing because markupsafe is a crucial dependency for them 