### PR TITLE
update to 2.1.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,8 @@
+{% set name = "markupsafe" %}
 {% set version = "2.1.3" %}
 
 package:
-  name: markupsafe
+  name: {{ name }}
   version: {{ version }}
 
 source:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,17 +1,17 @@
-{% set version = "2.1.1" %}
+{% set version = "2.1.3" %}
 
 package:
   name: markupsafe
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/M/MarkupSafe/MarkupSafe-{{ version }}.tar.gz
-  sha256: 7f91197cc9e48f989d12e4e6fbc46495c446636dfc81b9ccf50bb0ec74b91d4b
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/MarkupSafe-{{ version }}.tar.gz
+  sha256: af598ed32d6ae86f1b747b82783958b1a4ab8f617b06fe68795c7f026abbdcad
 
 build:
   number: 0
   skip: true  # [py<37]
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   build:


### PR DESCRIPTION
markupsafe 2.1.3

**Destination channel:** defaults

### Links

- [PKG-3701] 
- [Upstream repository](https://github.com/pallets/markupsafe/tree/2.1.3)

[PKG-3701]: https://anaconda.atlassian.net/browse/PKG-3701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ