### PR TITLE
markupsafe 3.0.2 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,10 +42,10 @@ test:
     # CI issues with testing downstream package astropy
     - jinja2  # [not win]
     - astropy  # [not win]
-    - pycaret  # [not win]
-    - moto
+    - pycaret  # [not (win or s390x)]
+    - moto  # [not s390x]
     - werkzeug
-    - nbconvert
+    - nbconvert  # [not (s390x and py>=312)]
 
 about:
   home: https://www.palletsprojects.com/p/markupsafe

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,14 +38,14 @@ test:
   commands:
     - pip check
     - pytest tests
-  downstreams:
-    # CI issues with testing downstream package astropy
-    - jinja2  # [not win]
-    - astropy  # [not win]
-    - pycaret  # [not (win or s390x)]
-    - moto  # [not s390x]
-    - werkzeug
-    - nbconvert  # [not (s390x and py>=312)]
+  # downstreams:
+  #   # CI issues with testing downstream package astropy
+  #   - jinja2  # [not win]
+  #   - astropy  # [not win]
+  #   - pycaret  # [not (win or s390x)]
+  #   - moto  # [not s390x]
+  #   - werkzeug
+  #   - nbconvert  # [not (s390x and py>=312)]
 
 about:
   home: https://www.palletsprojects.com/p/markupsafe

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,7 +43,7 @@ test:
     - jinja2  # [not win]
     - astropy  # [not win]
     - pycaret  # [not win]
-    - moto
+    - moto  # [not win]
     - werkzeug
     - nbconvert
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,17 +1,17 @@
 {% set name = "markupsafe" %}
-{% set version = "2.1.3" %}
+{% set version = "3.0.2" %}
 
 package:
   name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/MarkupSafe-{{ version }}.tar.gz
-  sha256: af598ed32d6ae86f1b747b82783958b1a4ab8f617b06fe68795c7f026abbdcad
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: ee55d3edf80167e48ea11a923c7386f4669df67d7994554387f84e7d8b0a2bf0
 
 build:
-  number: 1
-  skip: true  # [py<37]
+  number: 0
+  skip: true  # [py<39]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
@@ -20,7 +20,7 @@ requirements:
   host:
     - python
     - pip
-    - setuptools
+    - setuptools >=70.1
     - wheel
   run:
     - python
@@ -28,12 +28,16 @@ requirements:
     - jinja2 >=3.0.0
 
 test:
+  source_files:
+    - tests
   imports:
     - markupsafe
   requires:
     - pip
+    - pytest
   commands:
     - pip check
+    - pytest tests
   downstreams:  # [not win]
     # CI issues with testing downstream package astropy
     - jinja2  # [not win]
@@ -43,7 +47,7 @@ about:
   home: https://www.palletsprojects.com/p/markupsafe
   license: BSD-3-Clause
   license_family: BSD
-  license_file: LICENSE.rst
+  license_file: LICENSE.txt
   summary: Safely add untrusted strings to HTML/XML markup.
   description: |
       MarkupSafe implements a text object that escapes characters so it is

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,6 +42,10 @@ test:
     # CI issues with testing downstream package astropy
     - jinja2  # [not win]
     - astropy  # [not win]
+    - pycaret
+    - moto
+    - werkzeug
+    - nbconvert
 
 about:
   home: https://www.palletsprojects.com/p/markupsafe

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,7 @@ test:
     # CI issues with testing downstream package astropy
     - jinja2  # [not win]
     - astropy  # [not win]
-    - pycaret
+    - pycaret  # [not win]
     - moto
     - werkzeug
     - nbconvert

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,12 +38,12 @@ test:
   commands:
     - pip check
     - pytest tests
-  downstreams:  # [not win]
+  downstreams:
     # CI issues with testing downstream package astropy
     - jinja2  # [not win]
     - astropy  # [not win]
     - pycaret  # [not win]
-    - moto  # [not win]
+    - moto
     - werkzeug
     - nbconvert
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,7 +56,6 @@ about:
       injection attacks, meaning untrusted user input can safely be displayed
       on a page.
   doc_url: https://markupsafe.palletsprojects.com/
-  doc_source_url: https://github.com/pallets/markupsafe/blob/master/README.rst
   dev_url: https://github.com/pallets/markupsafe
 
 extra:


### PR DESCRIPTION
markupsafe 3.0.2 

**Destination channel:** Defaults

### Links

- [PKG-6883]
- dev_url:        https://github.com/pallets/markupsafe//tree/3.0.2
- conda_forge:    https://github.com/conda-forge/markupsafe-feedstock
- pypi:           https://pypi.org/project/markupsafe/3.0.2
- pypi inspector: https://inspector.pypi.io/project/markupsafe/3.0.2

### Explanation of changes:

- new version number


[PKG-6883]: https://anaconda.atlassian.net/browse/PKG-6883?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ